### PR TITLE
fix: add dependencies between build and cd workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     name: Build and Push Docker Image to GitHub Container Registry
+    needs: cd
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   cd:
     name: Handle Release and Deployment
+    needs: ci
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
This commit adds the "needs" keyword to the build and cd workflows in the GitHub Actions configuration. This ensures that the cd workflow will only run after the build workflow has successfully completed. This dependency ensures that the Docker image is built and pushed to the GitHub Container Registry before the release and deployment steps are executed.

Refactor the workflows to include the "needs" keyword for better workflow coordination and dependency management.

* **Please check if the PR fulfills these requirements**

- [x] The commit message follows the guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the current behavior?** (You can also link to an open issue here)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Other information**:

