### PR TITLE
fix(user): add "few" to valid recentTips options

### DIFF
--- a/src/chaturbate_poller/models/user.py
+++ b/src/chaturbate_poller/models/user.py
@@ -30,7 +30,9 @@ class User(BaseModel):
         Raises:
             ValueError: If `recentTips` is not valid.
         """
-        valid_tips = {"none", "some", "lots", "tons"}
+        # Added "few" to the valid tips (not documented in the API)
+        # https://chaturbate.com/apps/api/docs/objects.html#user
+        valid_tips = {"none", "few", "some", "lots", "tons"}
         if values.get("recentTips") not in valid_tips or not values.get("recentTips"):
             msg = "recentTips must be one of: none, some, lots, tons"
             raise ValueError(msg)


### PR DESCRIPTION
## **Please check whether the PR fulfills these requirements.** (Indicate with an `x` inside the square brackets where appropriate)

- [x] The commit message follows the guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

## **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes validation error for `user` object.

## **What is the current behavior?** (You can also link to an open issue here)
https://github.com/MountainGod2/chaturbate_poller/issues/232

## **What is the new behavior?** (If this is a feature change)
Added undocumented value `few` for users who have purchased, but not spent tokens.

## **Other information**:

https://chaturbate.com/apps/api/docs/objects.html#user :
> (string) recentTips: “none” (grey), “some” (dark blue), “lots” (light purple), or “tons” (dark purple)