### PR TITLE
feat: Add computed fields to the Message model to differentiate between private and public messages

### DIFF
--- a/src/chaturbate_poller/models/message.py
+++ b/src/chaturbate_poller/models/message.py
@@ -1,14 +1,47 @@
 """Models for the chat or private message system."""
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, computed_field
 
 
 class Message(BaseModel):
-    """Represents a chat or private message."""
+    """Model for the Message object."""
 
-    color: str
-    bg_color: str | None = Field(default=None, alias="bgColor")
-    message: str
-    font: str
-    from_user: str | None = Field(default=None, alias="fromUser")
-    to_user: str | None = Field(default=None, alias="toUser")
+    color: str = Field(..., description="The message color.")
+    """str: The message color."""
+    bg_color: str | None = Field(
+        None, alias="bgColor", description="The message background color. (Optional)"
+    )
+    """str | None: The message background color. (Optional)"""
+    message: str = Field(..., description="The message.")
+    """str: The message."""
+    font: str = Field(..., description="The message font.")
+    """str: The message font."""
+    from_user: str | None = Field(
+        None, alias="fromUser", description="The message sender. (Optional)"
+    )
+    """str | None: The message sender. (Optional)"""
+    to_user: str | None = Field(
+        None, alias="toUser", description="The message receiver. (Optional)"
+    )
+    """str | None: The message receiver. (Optional)"""
+
+    # See https://docs.pydantic.dev/2.0/usage/computed_fields/
+    # for the rationale behind ignoring the type errors below.
+    @computed_field  # type: ignore[misc]
+    @property
+    def is_private_message(self) -> bool:
+        """Determines if the message is a private message.
+
+        A private message typically has 'from_user' and 'to_user' fields.
+        """
+        return self.from_user is not None and self.to_user is not None
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def is_chat_message(self) -> bool:
+        """Determines if the message is a public chat message.
+
+        A public chat message typically does NOT have 'from_user' or 'to_user' fields
+        (or at least not both, as 'to_user' would be irrelevant in a public chat).
+        """
+        return self.from_user is None and self.to_user is None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -197,6 +197,40 @@ def message_example() -> Message:
 
 
 @pytest.fixture
+def private_message_example() -> Message:
+    """Fixture for an example Message object.
+
+    Returns:
+        Message: Example Message object.
+    """
+    return Message(
+        fromUser="example_user",
+        message="example message",
+        color="example_color",
+        font="example_font",
+        toUser="user",
+        bgColor="example_bg_color",
+    )
+
+
+@pytest.fixture
+def chat_message_example() -> Message:
+    """Fixture for an example Message object.
+
+    Returns:
+        Message: Example Message object.
+    """
+    return Message(
+        message="example message",
+        color="example_color",
+        font="example_font",
+        bgColor="example_bg_color",
+        fromUser=None,
+        toUser=None,
+    )
+
+
+@pytest.fixture
 async def stop_future() -> asyncio.Future[None]:
     """Fixture for the stop future.
 
@@ -229,39 +263,3 @@ def influxdb_handler() -> InfluxDBHandler:
         InfluxDBHandler: InfluxDBHandler instance.
     """
     return InfluxDBHandler()
-
-
-@pytest.fixture
-def log_record() -> logging.LogRecord:
-    """Fixture to create a log record.
-
-    Returns:
-        logging.LogRecord: Log record.
-    """
-    return logging.LogRecord(
-        name="test",
-        level=logging.INFO,
-        pathname=__file__,
-        lineno=10,
-        msg="events/user123/token123",
-        args=(),
-        exc_info=None,
-    )
-
-
-@pytest.fixture
-def log_record_with_args() -> logging.LogRecord:
-    """Fixture to create a log record with arguments.
-
-    Returns:
-        logging.LogRecord: Log record with arguments.
-    """
-    return logging.LogRecord(
-        name="test",
-        level=logging.INFO,
-        pathname=__file__,
-        lineno=10,
-        msg="User accessed the URL",
-        args=("events/user123/token123", 42),
-        exc_info=None,
-    )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -158,3 +158,18 @@ class TestModels:
                 ),
                 id="UNIQUE_EVENT_ID",
             )
+
+    def test_message_is_private_message(self, private_message_example: Message) -> None:
+        """Test the Message model type."""
+        message = private_message_example
+        assert message.from_user is not None
+        assert message.to_user is not None
+        assert message.is_private_message
+        assert not message.is_chat_message
+
+    def test_message_is_chat_message(self, chat_message_example: Message) -> None:
+        """Test the Message model type."""
+        message = chat_message_example
+        assert message.to_user is None
+        assert not message.is_private_message
+        assert message.is_chat_message


### PR DESCRIPTION
- [x] The commit message follows the guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Adds `is_private_message` and `is_chat_message` computed fields to the Message model.

* **What is the current behavior?** (You can also link to an open issue here)

Users currently have to differentiate manually based on whether certain fields are present.

* **What is the new behavior?** (If this is a feature change)

You can now use logic in the program itself to determine:

```python
message = Message(
        message="example message",
        color="example_color",
        font="example_font",
        bgColor="example_bg_color",
        fromUser=None,
        toUser=None,
    )

assert message.to_user is None
assert not message.is_private_message
assert message.is_chat_message
```


See https://github.com/MountainGod2/chaturbate_poller/issues/438 for details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added properties to messages to clearly indicate whether they are private or public chat messages.

- **Documentation**
  - Improved descriptions and docstrings for message fields, enhancing clarity.

- **Tests**
  - Introduced new tests and example messages to verify message type identification.
  - Removed outdated logging-related test fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->