### PR TITLE
ci: update uv lock command to only update this package during release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -55,7 +55,7 @@ jobs:
           cache-local-path: ${{ env.UV_CACHE_DIR }}
 
       - name: Setup | Update lock file to latest versions
-        run: uv lock --upgrade
+        run: uv lock --upgrade-package "chaturbate-poller"
 
       - name: Setup | Install Python & Project dependencies
         run: uv sync --group=build


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Continuous delivery pipeline updated to limit automated dependency lockfile updates to a single targeted package, minimizing unrelated upgrades and reducing risk during releases.
  * Improves build predictability and stability; no functional or UI changes for end users.
  * All other workflow steps remain unchanged; no changes to public APIs.
  * No action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->